### PR TITLE
lock: Do not include malloc.h

### DIFF
--- a/src/include/lock/zm_lock_types.h.in
+++ b/src/include/lock/zm_lock_types.h.in
@@ -11,7 +11,6 @@
 #endif
 #include <stdlib.h>
 #include <assert.h>
-#include <malloc.h>
 #include <errno.h>
 #include <pthread.h>
 #include "common/zm_common.h"

--- a/src/lock/zm_hmcs.c
+++ b/src/lock/zm_hmcs.c
@@ -110,9 +110,11 @@ static inline void reuse_qnode(zm_mcs_qnode_t *I){
 }
 
 static void* new_hnode() {
-    void *storage = memalign(ZM_CACHELINE_SIZE, sizeof(struct hnode));
-    if (storage == NULL) {
-        printf("Memalign failed in HMCS : new_hnode \n");
+    int err;
+    void *storage;
+    err = posix_memalign(&storage, ZM_CACHELINE_SIZE, sizeof(struct hnode));
+    if (err != 0) {
+        printf("posix_memalign failed in HMCS : new_hnode \n");
         exit(EXIT_FAILURE);
     }
     return storage;
@@ -248,9 +250,11 @@ static inline int nowaiters_helper(int level, struct hnode * L, zm_mcs_qnode_t *
 }
 
 static void* new_leaf(struct hnode *h, int depth) {
-    struct leaf *leaf = (struct leaf *)memalign(ZM_CACHELINE_SIZE, sizeof(struct leaf));
-    if (leaf == NULL) {
-        printf("Memalign failed in HMCS : new_leaf \n");
+    int err;
+    struct leaf *leaf;
+    err = posix_memalign((void **) &leaf, ZM_CACHELINE_SIZE, sizeof(struct leaf));
+    if (err != 0) {
+        printf("posix_memalign failed in HMCS : new_leaf \n");
         exit(EXIT_FAILURE);
     }
     leaf->cur_node = h;
@@ -341,7 +345,8 @@ static void free_hierarchy(int* particip_per_level){
 
 static void* new_lock(){
 
-    struct lock *L = (struct lock*)memalign(ZM_CACHELINE_SIZE, sizeof(struct lock));
+    struct lock *L;
+    posix_memalign((void **) &L, ZM_CACHELINE_SIZE, sizeof(struct lock));
 
     int max_threads;
     int *participants_at_level;
@@ -358,8 +363,10 @@ static void* new_lock(){
     for (int i=0; i < levels; i++) {
         total_locks_needed += max_threads / participants_at_level[i] ;
     }
-    struct hnode ** lock_locations = (struct hnode**)memalign(ZM_CACHELINE_SIZE, sizeof(struct hnode*) * total_locks_needed);
-    struct leaf ** leaf_nodes = (struct leaf**)memalign(ZM_CACHELINE_SIZE, sizeof(struct leaf*) * max_threads);
+    struct hnode ** lock_locations;
+    posix_memalign((void **) &lock_locations, ZM_CACHELINE_SIZE, sizeof(struct hnode*) * total_locks_needed);
+    struct leaf ** leaf_nodes;
+    posix_memalign((void **) &leaf_nodes, ZM_CACHELINE_SIZE, sizeof(struct leaf*) * max_threads);
 
     int threshold = DEFAULT_THRESHOLD;
     char *s = getenv("ZM_HMCS_THRESHOLD");

--- a/src/lock/zm_hmcs.c
+++ b/src/lock/zm_hmcs.c
@@ -468,7 +468,8 @@ static inline int hmcs_nowaiters(struct lock *L){
 }
 
 int zm_hmcs_init(zm_hmcs_t * handle) {
-    *handle  = (zm_hmcs_t) new_lock();
+    void *p = new_lock();
+    *handle  = (zm_hmcs_t) p;
     return 0;
 }
 

--- a/src/lock/zm_hmcs.c
+++ b/src/lock/zm_hmcs.c
@@ -262,7 +262,7 @@ static void* new_leaf(struct hnode *h, int depth) {
     leaf->took_fast_path = FALSE;
     struct hnode *tmp, *root_node;
     for(tmp = leaf->cur_node; tmp->parent != NULL; tmp = tmp->parent);
-        root_node = tmp;
+    root_node = tmp;
     leaf->root_node = root_node;
     return leaf;
 }

--- a/src/lock/zm_mcs.c
+++ b/src/lock/zm_mcs.c
@@ -135,7 +135,8 @@ static inline int free_lock(struct zm_mcs *L)
 
 
 int zm_mcs_init(zm_mcs_t *handle) {
-    *handle  = (zm_mcs_t) new_lock();
+    void *p = new_lock();
+    *handle  = (zm_mcs_t) p;
     return 0;
 }
 
@@ -147,26 +148,31 @@ int zm_mcs_destroy(zm_mcs_t *L) {
 
 /* Context-less API */
 int zm_mcs_acquire(zm_mcs_t L) {
-    return mcs_acquire((struct zm_mcs*)L) ;
+    /*
+      It is prohibited to convert intptr_t (=zm_mcs_t) to a non-void pointer.
+      Converting intptr_t to void*, then void* to any pointer type is permitted.
+      cf. https://stackoverflow.com/questions/34291377/converting-a-non-void-pointer-to-uintptr-t-and-vice-versa
+    */
+    return mcs_acquire((struct zm_mcs*)(void *)L) ;
 }
 
 int zm_mcs_release(zm_mcs_t L) {
-    return mcs_release((struct zm_mcs*)L) ;
+    return mcs_release((struct zm_mcs*)(void *)L) ;
 }
 
 int zm_mcs_nowaiters(zm_mcs_t L) {
-    return mcs_nowaiters((struct zm_mcs*)L) ;
+    return mcs_nowaiters((struct zm_mcs*)(void *)L) ;
 }
 
 /* Context-full API */
 int zm_mcs_acquire_c(zm_mcs_t L, zm_mcs_qnode_t* I) {
-    return mcs_acquire_c((struct zm_mcs*)L, I) ;
+    return mcs_acquire_c((struct zm_mcs*)(void *)L, I) ;
 }
 
 int zm_mcs_release_c(zm_mcs_t L, zm_mcs_qnode_t *I) {
-    return mcs_release_c((struct zm_mcs*)L, I) ;
+    return mcs_release_c((struct zm_mcs*)(void *)L, I) ;
 }
 
 int zm_mcs_nowaiters_c(zm_mcs_t L, zm_mcs_qnode_t *I) {
-    return mcs_nowaiters_c((struct zm_mcs*)L, I) ;
+    return mcs_nowaiters_c((struct zm_mcs*)(void *)L, I) ;
 }

--- a/src/lock/zm_mcs.c
+++ b/src/lock/zm_mcs.c
@@ -100,6 +100,7 @@ static inline int mcs_acquire(struct zm_mcs *L) {
         tid = get_hwthread_id(L->topo);
     }
     acquire_c(L, &L->local_nodes[tid]);
+    return 0;
 }
 
 static inline int mcs_release(struct zm_mcs *L) {

--- a/src/lock/zm_mcs.c
+++ b/src/lock/zm_mcs.c
@@ -43,14 +43,15 @@ static void* new_lock() {
     struct zm_mcs_qnode *qnodes;
 
 
-    struct zm_mcs *L = (struct zm_mcs*)memalign(ZM_CACHELINE_SIZE, sizeof(struct zm_mcs));
+    struct zm_mcs *L;
+    posix_memalign((void **) &L, ZM_CACHELINE_SIZE, sizeof(struct zm_mcs));
 
     hwloc_topology_init(&L->topo);
     hwloc_topology_load(L->topo);
 
     max_threads = hwloc_get_nbobjs_by_type(L->topo, HWLOC_OBJ_PU);
 
-    qnodes = (struct zm_mcs_qnode*) memalign(ZM_CACHELINE_SIZE, sizeof(struct zm_mcs_qnode) * max_threads);
+    posix_memalign((void **) &qnodes, ZM_CACHELINE_SIZE, sizeof(struct zm_mcs_qnode) * max_threads);
 
     zm_atomic_store(&L->lock, (zm_ptr_t)ZM_NULL, zm_memord_release);
     L->local_nodes = qnodes;

--- a/src/queue/zm_faqueue.c
+++ b/src/queue/zm_faqueue.c
@@ -57,7 +57,7 @@ static inline zm_facell_t *zm_facell_find(zm_faseg_t **seg, zm_ulong_t cell_id) 
 int zm_faqueue_init(zm_faqueue_t *q) {
     q->head = 0;
     zm_atomic_store(&q->tail, 0, zm_memord_release);
-    q->seg_head = (zm_ptr_t)zm_faseg_alloc(0);
+    q->seg_head = (zm_ptr_t)(void *)zm_faseg_alloc(0);
     zm_atomic_store(&q->seg_tail, q->seg_head, zm_memord_release);
     return 0;
 }
@@ -78,7 +78,7 @@ int zm_faqueue_dequeue(zm_faqueue_t* q, void **data) {
         *data = seg_head->cells[q->head].data;
         q->head++;
         if (q->head % ZM_MAX_FASEG_SIZE == 0) { /* processed all seg_head */
-            q->seg_head = (zm_ptr_t)zm_faseg_advance(seg_head, q->head);
+            q->seg_head = (zm_ptr_t)(void*)zm_faseg_advance(seg_head, q->head);
             free(seg_head);
         }
     }


### PR DESCRIPTION
malloc.h is obsolete and stdlib.h is enough for using malloc(3) etc.

Including malloc.h here causes a build failure when izem is used
in MPICH, which redefines symbol names like "malloc" to keep users
from calling them (to force use of tracing-enabled versions.)