### PR TITLE
queue: Add compile/run-time selection logic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -291,6 +291,44 @@ esac
 
 AC_SUBST(ZM_COND_IF)
 
+# Default queue interface
+
+AC_ARG_WITH([queue_if],
+[  --with-queue-if@<:@=QUEUE_IF@:>@   define the default queue interface being
+                          exposed by Izem (i.e., zm_queue_t and associated
+                          routines. QUEUE_IF represents the name of the
+                          underlying queue to be used. Possible values are:
+                          gl   - Global lock
+                          ms   - TBA
+                          swp  - TBA
+                          fa   - Fetch and add
+                          runtime - Runtime selection through ZM_QUEUE_IF environment variable
+],,
+[with_queue_if=gl])
+
+case "$with_queue_if" in
+    gl)
+        ZM_QUEUE_CONF=ZM_GLQUEUE_IF
+    ;;
+    ms)
+        ZM_QUEUE_CONF=ZM_MSQUEUE_IF
+    ;;
+    swp)
+        ZM_QUEUE_CONF=ZM_SWPQUEUE_IF
+    ;;
+    fa)
+        ZM_QUEUE_CONF=ZM_FAQUEUE_IF
+    ;;
+    # mbpqueue has a different function signature, so won't be supported here
+    runtime)
+        ZM_QUEUE_CONF=ZM_RUNTIMEQUEUE_IF
+    ;;
+    *)
+        AC_MSG_ERROR([Unknown value $with_queue_if for with-queue-if])
+    ;;
+esac
+
+AC_SUBST(ZM_QUEUE_CONF)
 
 AC_ARG_WITH([hwloc],
             [AS_HELP_STRING([--with-hwloc], [Set path to hwloc. Default: auto detect.])],
@@ -340,6 +378,7 @@ AC_CONFIG_FILES([Makefile
                  src/include/lock/zm_lock.h
                  src/include/lock/zm_lock_types.h
                  src/include/cond/zm_cond.h
+                 src/include/queue/zm_queue.h
                  test/Makefile
                  test/regres/Makefile
                  test/regres/lock/Makefile

--- a/src/include/queue/zm_queue.h.in
+++ b/src/include/queue/zm_queue.h.in
@@ -1,0 +1,117 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#ifndef _ZM_QUEUE_H
+#define _ZM_QUEUE_H
+
+#define ZM_RUNTIMEQUEUE_IF 0
+#define ZM_GLQUEUE_IF      1
+#define ZM_MSQUEUE_IF      2
+#define ZM_SWPQUEUE_IF     3
+#define ZM_FAQUEUE_IF      4
+#define ZM_MPBQUEUE_IF     5
+
+extern int zm_queue_if;
+
+int zm_queue_parse_name(const char *name);
+
+/* default queue interface, given by configure */
+#define ZM_QUEUE_CONF @ZM_QUEUE_CONF@
+
+/* ZM_QUEUE_IF: used in the library code to determine which queue implementation to use.
+ * It is mapped to a constant if a user chooses a particular queue, or mapped to zm_queue_if
+ * (variable) if a user chooses `runtime` at configure time.
+ * If it is mapped to a constant (configure-time selection), a reasonable compiler can
+ * easily eliminate branches, so there won't be performance penalty due to queue selection. */
+#if ZM_QUEUE_CONF == ZM_RUNTIMEQUEUE_IF
+#  define ZM_QUEUE_IF      zm_queue_if
+#else
+#  define ZM_QUEUE_IF      ZM_QUEUE_CONF
+#endif /* ZM_QUEUE_CONF == ZM_RUNTIMEQUEUE_IF */
+
+/* Generic implementation of the queue interface */
+
+#include <assert.h>
+
+#include <queue/zm_glqueue.h>
+#include <queue/zm_msqueue.h>
+#include <queue/zm_swpqueue.h>
+#include <queue/zm_faqueue.h>
+
+static inline int zm_queue_init(zm_queue_t *q)
+{
+    if (ZM_QUEUE_CONF == ZM_RUNTIMEQUEUE_IF) {
+        const char *env_str = getenv("ZM_QUEUE_IF");
+        if (env_str == NULL) {
+            /* Fall back to default */
+            zm_queue_if = ZM_GLQUEUE_IF;
+        } else {
+            zm_queue_if = zm_queue_parse_name(env_str);
+        }
+    }
+
+    switch (ZM_QUEUE_IF) {
+        case ZM_GLQUEUE_IF:
+            return zm_glqueue_init(&q->glqueue);
+
+        case ZM_MSQUEUE_IF:
+            return zm_msqueue_init(&q->msqueue);
+
+        case ZM_SWPQUEUE_IF:
+            return zm_swpqueue_init(&q->swpqueue);
+
+        case ZM_FAQUEUE_IF:
+            return zm_faqueue_init(&q->faqueue);
+
+        default:
+            fprintf(stderr, "izem: Unknown queue interface specified. Falling back to glqueue.\n");
+            zm_queue_if = ZM_GLQUEUE_IF;
+            return zm_glqueue_init(&q->glqueue);
+    }
+}
+
+static inline int zm_queue_enqueue(zm_queue_t* q, void *data)
+{
+    switch (ZM_QUEUE_IF) {
+        case ZM_GLQUEUE_IF:
+            return zm_glqueue_enqueue(&q->glqueue, data);
+
+        case ZM_MSQUEUE_IF:
+            return zm_msqueue_enqueue(&q->msqueue, data);
+
+        case ZM_SWPQUEUE_IF:
+            return zm_swpqueue_enqueue(&q->swpqueue, data);
+
+        case ZM_FAQUEUE_IF:
+            return zm_faqueue_enqueue(&q->faqueue, data);
+
+        default:
+            assert(0);
+            return 0;
+    }
+}
+
+static inline int zm_queue_dequeue(zm_queue_t* q, void **data)
+{
+    switch (ZM_QUEUE_IF) {
+        case ZM_GLQUEUE_IF:
+            return zm_glqueue_dequeue(&q->glqueue, data);
+
+        case ZM_MSQUEUE_IF:
+            return zm_msqueue_dequeue(&q->msqueue, data);
+
+        case ZM_SWPQUEUE_IF:
+            return zm_swpqueue_dequeue(&q->swpqueue, data);
+
+        case ZM_FAQUEUE_IF:
+            return zm_faqueue_dequeue(&q->faqueue, data);
+
+        default:
+            assert(0);
+            return 0;
+    }
+}
+
+#endif /* #ifndef_ZM_QUEUE_H */

--- a/src/include/queue/zm_queue_types.h
+++ b/src/include/queue/zm_queue_types.h
@@ -82,4 +82,14 @@ struct zm_mpbqueue {
     int last_bucket_set;
 };
 
+/* Common structure to allow runtime selection */
+
+typedef union zm_queue {
+    zm_glqueue_t  glqueue;
+    zm_msqueue_t  msqueue;
+    zm_swpqueue_t swpqueue;
+    zm_faqueue_t  faqueue;
+    zm_mpbqueue_t mpbqueue;
+} zm_queue_t;
+
 #endif /* _ZM_QUEUE_TYPES_H */

--- a/src/include/queue/zm_queue_types.h
+++ b/src/include/queue/zm_queue_types.h
@@ -71,6 +71,8 @@ struct zm_faqueue {
     zm_atomic_ptr_t     seg_tail;
 };
 
+typedef struct zm_mpbqueue zm_mpbqueue_t;
+
 struct zm_mpbqueue {
     zm_swpqueue_t *buckets;
     int nbuckets;

--- a/src/queue/Makefile.mk
+++ b/src/queue/Makefile.mk
@@ -4,6 +4,7 @@
 #
 
 zm_sources += \
+	queue/zm_queue.c \
 	queue/zm_glqueue.c \
 	queue/zm_swpqueue.c \
 	queue/zm_faqueue.c \

--- a/src/queue/zm_queue.c
+++ b/src/queue/zm_queue.c
@@ -1,0 +1,33 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <string.h>
+#include "queue/zm_queue.h"
+
+int zm_queue_if;
+
+struct zm_queue_name_pair {
+    int type;
+    const char *name;
+};
+
+static struct zm_queue_name_pair name_pairs[] = {
+    { ZM_GLQUEUE_IF, "gl" },
+    { ZM_MSQUEUE_IF, "ms" },
+    { ZM_SWPQUEUE_IF, "swp" },
+    { ZM_FAQUEUE_IF, "fa" },
+    { -1, NULL } /* name == NULL indicates the end of the list */
+};
+
+int zm_queue_parse_name(const char *name)
+{
+    int i;
+    for (i = 0; name_pairs[i].name != NULL; i++) {
+        /* Compare first few characters only -- so all of "gl", "glq", "glqueue" work */
+        if (strncmp(name, name_pairs[i].name, strlen(name_pairs[i].name)) == 0)
+            return name_pairs[i].type;
+    }
+    return -1; /* Matching queue type not found */
+}


### PR DESCRIPTION
This patch adds a generic queue type `zm_queue_t` and allows
users to select a queue implementation underneath through either
configure option or an environment variable.

With this feature, applications of izem can use `zm_queue_t` and
let izem decide which queue to use. Applications may still directly
specify a particular queue implementation too.